### PR TITLE
timegraph: Preserve state selection upon repaint

### DIFF
--- a/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/StateRectangle.java
+++ b/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/StateRectangle.java
@@ -96,7 +96,12 @@ public class StateRectangle extends Rectangle {
         }
 
         /* Set initial selection state and selection listener. */
-        setSelected(false);
+        if (this.equals(viewer.getSelectedState())) {
+            setSelected(true);
+            viewer.setSelectedState(this);
+        } else {
+            setSelected(false);
+        }
         setOnMouseClicked(e -> {
             if (e.getButton() != MouseButton.PRIMARY) {
                 return;


### PR DESCRIPTION
Re-apply the state selection when a repaint is done by comparing with
the equivalent rectangle from the old scene graph.

Fixes #15.

Signed-off-by: Michael Jeanson <mjeanson@efficios.com>