### PR TITLE
timegraph: Add selection and mouse pivot to zoom

### DIFF
--- a/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/DebugOptions.java
+++ b/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/DebugOptions.java
@@ -116,6 +116,19 @@ public class DebugOptions {
      */
     public final ConfigOption<Double> zoomStep = new ConfigOption<>(0.08);
 
+    /**
+     * Each zoom action will be centered on the center of the selection if it's
+     * currently visible.
+     */
+    public final ConfigOption<Boolean> zoomPivotOnSelection = new ConfigOption<>(true);
+
+    /**
+     * Each zoom action will be centered on the current mouse position if the
+     * zoom action originates from a mouse event. If zoomPivotOnSelection is
+     * enabled, it has priority.
+     */
+    public final ConfigOption<Boolean> zoomPivotOnMousePosition = new ConfigOption<>(true);
+
     // ------------------------------------------------------------------------
     // State rectangles
     // ------------------------------------------------------------------------

--- a/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/toolbar/ZoomInButton.java
+++ b/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/toolbar/ZoomInButton.java
@@ -31,9 +31,7 @@ class ZoomInButton extends Button {
         setGraphic(new ImageView(icon));
         setTooltip(new Tooltip(Messages.sfZoomInActionDescription));
         setOnAction(e -> {
-            // TODO Pivot could be the current time selection if it's in the
-            // visible time range.
-            viewer.getZoomActions().zoom(null, true);
+            viewer.getZoomActions().zoom(true, false, null);
         });
     }
 }

--- a/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/toolbar/ZoomOutButton.java
+++ b/tmf2/org.lttng.scope.tmf2.views.ui/src/org/lttng/scope/tmf2/views/ui/timeline/widgets/timegraph/toolbar/ZoomOutButton.java
@@ -32,8 +32,7 @@ class ZoomOutButton extends Button {
         setGraphic(new ImageView(icon));
         setTooltip(new Tooltip(Messages.sfZoomOutActionDescription));
         setOnAction(e -> {
-            // TODO Should pivot be the current selection, or just the center?
-            viewer.getZoomActions().zoom(null, false);
+            viewer.getZoomActions().zoom(false, false, null);
         });
     }
 }


### PR DESCRIPTION
This patch implements the following logic for the zoom pivot point
instead of the current behavior of using the center of the visible area:

  * Use the mouse pointer X position, if ctrl+shift are pressed and the
    zoom action is initiated by a mouse scroll event.

  * Use the center point of the current time range selection, only if said
    point is in the current visible range.

  * Use the mouse pointer X position, if ctrl is pressed and the zoom action
    is initiated by a mouse scroll event.

  * Use the center of the visible window.

The mouse and selection conditions can also be disabled through appropriate
debug options.

Fixes #20.

Signed-off-by: Michael Jeanson <mjeanson@efficios.com>